### PR TITLE
:recycle: close webview panel if document is active

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Open the command list with `Ctrl+Shift+P` (Windows) or `Cmd+Shift+P` (MacOS)
 
 ## TODO
 
-- [ ] Improve the WebView Panel for the Git Notes Summary Page - <https://github.com/jrosco/vscode-git-notes/pull/6>
+- [ ] Improve the WebView Panel for the Git Notes Summary Page - <https://github.com/jrosco/vscode-git-notes/pull/6#issuecomment-1646719619>
 
 ## License
 

--- a/src/ui/webview.ts
+++ b/src/ui/webview.ts
@@ -53,7 +53,7 @@ export class GitNotesPanel {
     );
 
     let webViewTab = vscode.window.onDidChangeActiveTextEditor((editor) => {
-      // Check if the WebView panel is not active and not close / dispose of panel
+      // Check if the WebView panel is not active and close / dispose of panel
       if (editor?.document !== undefined) {
         GitNotesPanel.currentPanel?._panel.dispose();
         webViewTab.dispose();


### PR DESCRIPTION
Doing this to be safe (for now), as it can be confusing to leave this open when doing git push/fetch, as it may run in the wrong directory that the user thinks they're in..

In the future, I need to improve this to keep track of the directory that was opened in webview and when a update is performed e.g git push, refresh the webview panel.