### PR TITLE
🐛  Fix - When hitting escaping Git add note command add note inputbox not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "git-notes" extension will be documented in this file
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased Changes]
+
+### Fixed
+
+- When user hit ESC from `InputBox` when running `extension.addGitNoteMessage` the command tries to add a message/note instead of cancelling input (<https://github.com/jrosco/vscode-git-notes/pull/11>)
+
+## [Released]
+
 ## [0.0.1] - 2023-07-23
 
 ### Added

--- a/src/ui/input.ts
+++ b/src/ui/input.ts
@@ -38,7 +38,7 @@ export class NotesInput {
 		});
 
 		if (inputValue === undefined) {
-			vscode.window.showInformationMessage('No value provided.');
+			vscode.window.showInformationMessage(`${this.prompt} Cancelled`);
 			return false;
 		}
 		if (inputConfirmation) {

--- a/src/ui/input.ts
+++ b/src/ui/input.ts
@@ -39,7 +39,7 @@ export class NotesInput {
 
 		if (inputValue === undefined) {
 			vscode.window.showInformationMessage('No value provided.');
-			return "";
+			return false;
 		}
 		if (inputConfirmation) {
 			const confirm = await vscode.window.showInformationMessage(


### PR DESCRIPTION
This change addresses an issue where pressing the "Escape" key on the Git add note InputBox does not cancel the input as expected. Instead, it attempts to add a message. The fix ensures that pressing "Escape" properly cancels the input process.