### PR TITLE
:beer: [fix] Added URL placeholder setting to help with an issue where some…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased Changes]
 
+### Fix
+
+- [#28](https://github.com/jrosco/vscode-git-notes/pull/28) 🍺 Added URL placeholder setting to help with an issue where some SCMs have different commit URLs
+
 ## [0.2.0]
 
 ### Added

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -12,8 +12,8 @@ public get confirmPushAndFetchCommands(): boolean {
  }
 ```
 
-- [ ] Some links to open commits are different e.g github use `commit` and bitbucket use `commits` in the url linked to commit info
-  - [ ] Have a way to use different urls for different SCM provider like Bitbucket.
+- [x] Some links to open commits are different e.g github use `commit` and bitbucket use `commits` in the url linked to commit info
+  - [x] [#28](https://github.com/jrosco/vscode-git-notes/pull/28) Have a way to use different urls for different SCM provider like Bitbucket.
 - [ ] Check the `confirmPushAndFetchCommands` setting is working correctly.
 - [ ] Do proper `edit` and `append` git commands, currently to `edit` or `append` a note, I'm using `git notes add --force [commitSha]` (seems to be the same results)
 - [ ] Add a Collapse / Expand HTML tag to the WebView for notes.

--- a/package.json
+++ b/package.json
@@ -79,6 +79,20 @@
           "type": "number",
           "default": 3,
           "description": "Number of Git Notes to load at a time."
+        },
+        "git-notes.gitUrlSCMProvider": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "github.com/{path1}/{path2}/commit/{commitId}",
+            "bitbucket.org/{path1}/{path2}/commits/{commitId}",
+            "gitlab.com/{path1}/{path2}/commit/{commitId}",
+            "git.launchpad.net/{path1}/commit/?id={commitId}"
+          ],
+          "description":
+              "List of SCM commit URLs with placeholders for dynamic path segments and commit IDs. Use {path1}, {path2}, {commitId} etc, as placeholders. You can also add your own custom URLs with appropriate placeholders. 'https://' is added automatically to the URLs."
         }
       }
     },

--- a/settings.json
+++ b/settings.json
@@ -8,5 +8,11 @@
     "git-notes.confirmPushAndFetchCommands": true,
     "git-notes.confirmRemovalCommands": true,
     "git-notes.confirmPruneCommands": true,
-    "git-notes.gitNotesLoadLimit": 3
+    "git-notes.gitNotesLoadLimit": 3,
+    "git-notes.gitUrlSCMProvider": [
+        "github.com/{path1}/{path2}/commit/{commitId}",
+        "bitbucket.org/{path1}/{path2}/commits/{commitId}",
+        "gitlab.com/{path1}/{path2}/commit/{commitId}",
+        "git.launchpad.net/{path1}/commit/?id={commitId}"
+  ]
 }

--- a/src/git/cmd.ts
+++ b/src/git/cmd.ts
@@ -635,7 +635,7 @@ export class GitCommands {
     this.logger.trace("_getGitUrl()");
     try {
       const result = await new Promise<string>((resolve, reject) => {
-        this.git.remote(['get-url', 'origin'], (err, result) => {
+        this.git.remote(["get-url", "origin"], (err, result) => {
           if (err) {
             reject("Error retrieving Git URL");
           } else {
@@ -645,10 +645,11 @@ export class GitCommands {
       });
 
       let gitUrl = result.trim();
-
+      const regex = /^(?:git:\/\/|git@|git\/\/\/)(.+)$/i;
       // Convert SSH URL to HTTPS URL if necessary
-      if (gitUrl.startsWith('git@')) {
-        gitUrl = gitUrl.replace(/:/, '/').replace(/.git$/, '').replace(/^git@/, 'https://');
+      if (gitUrl.match(regex)) {
+        gitUrl = gitUrl.replace(/:/, "/").replace(/.git$/, "");
+        gitUrl = gitUrl.replace(regex, "https://$1");
       }
 
       this.logger.info(`return ${gitUrl}`);

--- a/src/git/utils.ts
+++ b/src/git/utils.ts
@@ -1,6 +1,91 @@
-import * as vscode from 'vscode';
+import { GitNotesSettings } from "../settings";
+import { LoggerService } from "../log/service";
 
-import { RepositoryDetails } from '../interface';
-import { CommitDetails } from '../interface';
+export class GitUtils {
+  private settings: GitNotesSettings;
+  private gitUrlSCMProvider: string[];
+  private logger: LoggerService;
 
-export class GitUtils {}
+  constructor() {
+    this.settings = new GitNotesSettings();
+    this.gitUrlSCMProvider = this.settings.gitUrlSCMProvider;
+    this.logger = LoggerService.getInstance(this.settings.logLevel);
+  }
+
+  public convertGitUrlSCMProvider(
+    gitUrl: string,
+    commitHash: string
+  ): string | undefined {
+    this.logger.info(
+      `GitNotes: convertGitUrlSCMProvider called with ${gitUrl} and commitHash ${commitHash}`
+    );
+    for (const gitSCMProvider of this.gitUrlSCMProvider) {
+      this.logger.debug(`GitNotes: gitUrlSCMProvider is ${gitSCMProvider}`);
+      // Extract the parts of the URL
+      const parsedUrl = new URL(gitUrl);
+      const protocol = parsedUrl.protocol;
+      const domain = parsedUrl.hostname;
+      const pathname = parsedUrl.pathname;
+      // Extract slash(/) paths from pathname
+      const pathParts = pathname.split("/").filter((part) => part !== ""); // Split pathname and remove empty parts
+      // Check for a match between gitUrl and gitUrlSCMProvider entries
+      const getMatch = gitSCMProvider.includes(domain);
+      const isValidCommitHash =
+        commitHash !== undefined && commitHash.trim() !== "";
+      // Check if the gitUrlSCMProvider is in the gitUrl
+      if (getMatch && isValidCommitHash) {
+        this.logger.debug(`GitNotes: ${gitUrl} is supported`);
+        // Define a regular expression to match values inside curly brackets
+        const regex = /\{([^{}]+)\}/g;
+        // Initialize an array to store the names and index numbers of placeholders
+        const placeholders: {
+          position: number;
+          name: string;
+          placeholder: string;
+        }[] = [];
+        let match;
+        let index = 0;
+        while ((match = regex.exec(gitSCMProvider)) !== null) {
+          const [fullMatch, name] = match; // fullMatch is the full matched string, name is the value inside curly brackets
+          // Ignore the commitId placeholder
+          if (name !== "commitId") {
+            placeholders.push({
+              position: index,
+              name: name,
+              placeholder: fullMatch,
+            });
+            index++;
+          }
+        }
+        // handle path# placeholders
+        const regexPaths = /{path\d+}/g;
+        const pathMatch = gitSCMProvider.match(regexPaths);
+		let gitCommitUrl = gitSCMProvider;
+        for (const path of pathMatch ?? []) {
+          const index = placeholders.findIndex(
+            (placeholder) => placeholder.placeholder === path
+          );
+          const position = placeholders[index].position;
+          gitCommitUrl = gitCommitUrl.replace(path, pathParts[position]);
+        }
+        const fullGitCommitUrl = `${protocol}//${gitCommitUrl
+          .replace("{commitId}", commitHash)
+          .replace(/\/\//g, "/")}`;
+        // Return the new URL
+        if (fullGitCommitUrl) {
+          this.logger.debug(`GitNotes: gitCommitUrl is ${fullGitCommitUrl}`);
+          return fullGitCommitUrl;
+        }
+      }
+    }
+    this.logger.debug(
+      `GitNotes: ${gitUrl} is not supported returning default URL`
+    );
+    return `${gitUrl}/commit/${commitHash}`;
+  }
+
+  // Getters
+  public get getGitUrlSCMProvider() {
+    return this.gitUrlSCMProvider;
+  }
+}

--- a/src/git/utils.ts
+++ b/src/git/utils.ts
@@ -60,7 +60,7 @@ export class GitUtils {
         // handle path# placeholders
         const regexPaths = /{path\d+}/g;
         const pathMatch = gitSCMProvider.match(regexPaths);
-		let gitCommitUrl = gitSCMProvider;
+        let gitCommitUrl = gitSCMProvider;
         for (const path of pathMatch ?? []) {
           const index = placeholders.findIndex(
             (placeholder) => placeholder.placeholder === path

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -79,8 +79,18 @@ export class GitNotesSettings {
 	}
 
 	public get gitNotesLoadLimit(): number {
-		this.logger.debug("gitNotesLoadLimit get sortDateNewestFirst called");
+		this.logger.debug("GitNotesSettings get gitNotesLoadLimit called");
 		return this._config.get('gitNotesLoadLimit', 3);
+	}
+
+	public get gitUrlSCMProvider(): string[] {
+		this.logger.debug("GitNotesSettings get gitUrlSCMProvider called");
+		return this._config.get("gitUrlSCMProvider", [
+      "github.com/{path1}/{path2}/commit/{commitId}",
+      "bitbucket.org/{path1}/{path2}/commits/{commitId}",
+      "gitlab.com/{path1}/{path2}/commit/{commitId}",
+      "git.launchpad.net/{path1}/commit/?id={commitId}",
+    ]);
 	}
 
 	public get onDidChangeConfig(): vscode.Event<vscode.ConfigurationChangeEvent> {


### PR DESCRIPTION
… SCMs have different commit URLs

Added the `gitUrlSCMProvider` setting.

Default settings

* "github.com/{owner}/{repo}/commit/{commitId}"
* "bitbucket.org/{repo}/{owner}/commits/{commitId}"

if no URL placeholder is found use default URL
`${gitUrl}/commit/${commitHash}`. `gitUrl` is the URL from the git config

Note, Users can add there own custom URLs, if required