### PR TITLE
:fire: Remove parser code date from `_parseCommitDetail()`. Date is f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - [#28](https://github.com/jrosco/vscode-git-notes/pull/28) 🍺 Added URL placeholder setting to help with an issue where some SCMs have different commit URLs
 
+### Changed
+
+- [#30](https://github.com/jrosco/vscode-git-notes/pull/30) 🔥 Remove parser code date from `_parseCommitDetail()`. Date is found with the `_getGitNotesList()` method now
+
 ## [0.2.0] - 2023-08-01
 
 ### Added

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,6 @@
 # TODO List
 
-- [ ] Have the `settings.ts` log the results found.
+- [x] Have the `settings.ts` log the results found.
 
 Example
 
@@ -14,7 +14,7 @@ public get confirmPushAndFetchCommands(): boolean {
 
 - [x] Some links to open commits are different e.g github use `commit` and bitbucket use `commits` in the url linked to commit info
   - [x] [#28](https://github.com/jrosco/vscode-git-notes/pull/28) Have a way to use different urls for different SCM provider like Bitbucket.
-- [ ] Check the `confirmPushAndFetchCommands` setting is working correctly.
+- [x] Check the `confirmPushAndFetchCommands` setting is working correctly.
 - [ ] Do proper `edit` and `append` git commands, currently to `edit` or `append` a note, I'm using `git notes add --force [commitSha]` (seems to be the same results)
 - [ ] Add a Collapse / Expand HTML tag to the WebView for notes.
 - [ ] Add some search functionality.
@@ -33,3 +33,6 @@ const gitOptions: SimpleGitOptions = {
   config: ['core.sshCommand=/usr/bin/ssh -i ~/.ssh/id_rsa_git_note_test'], // Change this to the path of your private SSH key
 };
 ```
+
+- [x] Remove parser code date from `_parseCommitDetail())`. Date is found with the `_getGitNotesList()` method now
+- [ ] Get authors email address and add to commit details interface

--- a/src/git/cmd.ts
+++ b/src/git/cmd.ts
@@ -419,18 +419,11 @@ export class GitCommands {
     );
     const author: string = authorLine ? authorLine.split(":")[1].trim() : "";
 
-    const dateLine: string | undefined = lines.find((line) =>
-      line.startsWith("Date:")
-    );
-    const date: string = dateLine ? dateLine.replace("Date:", "").trim() : "";
-    const dateObject = new Date(date);
-
     // Get file changes
     const fileChanges = await this._getCommitFileChanges(commitSHA);
 
     const commit = {
       author: author,
-      date: dateObject,
       message: message,
       fileChanges: fileChanges,
     };


### PR DESCRIPTION
…ound with the `_getGitNotesList()` method now