### PR TITLE
:bug: There is an issue on window with the way "//" are treated, it r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased Changes]
 
+## [0.2.1]
+
+### Bug
+
+- 🐛 [#31](https://github.com/jrosco/vscode-git-notes/pull/31) There is an issue on windows with the way "//" are treated, it removes the "//" from path. This temp fix will replace the "//" with "/"
+
 ## [0.2.0]
 
 ### Added
@@ -50,3 +56,4 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 [0.0.1]: https://github.com/jrosco/vscode-git-notes/compare/a9fdfb1...0.0.1
 [0.1.0]: https://github.com/jrosco/vscode-git-notes/compare/0.0.1...0.1.0
 [0.2.0]: https://github.com/jrosco/vscode-git-notes/compare/0.1.0...0.2.0
+[0.2.1]: https://github.com/jrosco/vscode-git-notes/compare/0.2.0...0.2.0-patch1

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/jrosco/vscode-git-notes.git"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/src/ui/webview.ts
+++ b/src/ui/webview.ts
@@ -60,6 +60,8 @@ export class GitNotesPanel {
     panel.webview.onDidReceiveMessage(async (message) => {
       const cmd = new GitCommands();
       const settings = new GitNotesSettings();
+      const logger = LoggerService.getInstance(settings.logLevel);
+      logger.debug(`webview onDidReceiveMessage: ${message.command}, ${message.repositoryPath}`);
       switch (message.command) {
         case 'repoOpen':
           await vscode.env.openExternal(vscode.Uri.parse(message.repositoryUrl));
@@ -84,10 +86,12 @@ export class GitNotesPanel {
           await vscode.env.openExternal(vscode.Uri.parse(message.commitUrl));
           break;
         case 'commitEdit':
+          logger.debug(`webview commitEdit: ${message.commitHash}, ${message.repositoryPath}`);
           await vscode.commands.executeCommand('extension.addOrEditGitNote',
             message.commitHash, message.repositoryPath);
           break;
         case 'commitRemove':
+          logger.debug(`webview commitRemove: ${message.commitHash}, ${message.repositoryPath}`);
           await vscode.commands.executeCommand('extension.removeGitNote',
             message.commitHash, message.repositoryPath);
           break;
@@ -137,7 +141,7 @@ export class GitNotesPanel {
     this.logger.debug(`refreshWebViewContent(${repositoryPath}, ${repositoryDetails})`);
     if (this._panel && repositoryDetails !== undefined) {
       this.logger.debug(`refreshWebViewContent _panel: ${this._panel}`);
-      const webViewContent = this._getWebviewContent(this.repositoryPath, repositoryDetails);
+      const webViewContent = this._getWebviewContent(repositoryPath, repositoryDetails);
       this._panel.webview.html = webViewContent;
     }
   }
@@ -157,7 +161,7 @@ export class GitNotesPanel {
 
   private _getWebviewContent(repositoryPath: string | undefined, repositoryDetails: RepositoryDetails[]) {
     // Filter repositoryDetails based on exact match of repositoryPath
-    if (this.repositoryPath !== undefined) {
+    if (repositoryPath !== undefined) {
       const filteredRepositoryDetails = repositoryDetails.filter(details =>
         details.repositoryPath === repositoryPath
       );
@@ -197,27 +201,27 @@ export class GitNotesPanel {
         });
         document.getElementById('repoAdd').addEventListener('click', () => {
           // When the button is clicked, call the extension method to perform the task
-          vscode.postMessage({ command: 'repoAdd', repositoryPath: '${details.repositoryPath}', refresh: true });
+          vscode.postMessage({ command: 'repoAdd', repositoryPath: '${details.repositoryPath?.replace(/\\/g, '\\\\')}', refresh: true });
         });
         document.getElementById('repoPrune').addEventListener('click', () => {
           // When the button is clicked, call the extension method to perform the task
-          vscode.postMessage({ command: 'repoPrune', repositoryPath: '${details.repositoryPath}'});
+          vscode.postMessage({ command: 'repoPrune', repositoryPath: '${details.repositoryPath?.replace(/\\/g, '\\\\')}'});
         });
         document.getElementById('repoPush').addEventListener('click', () => {
           // When the button is clicked, call the extension method to perform the task
-          vscode.postMessage({ command: 'repoPush', repositoryPath: '${details.repositoryPath}', refresh: true });
+          vscode.postMessage({ command: 'repoPush', repositoryPath: '${details.repositoryPath?.replace(/\\/g, '\\\\')}', refresh: true });
         });
         document.getElementById('repoFetch').addEventListener('click', () => {
           // When the button is clicked, call the extension method to perform the task
-          vscode.postMessage({ command: 'repoFetch', repositoryPath: '${details.repositoryPath}', refresh: true });
+          vscode.postMessage({ command: 'repoFetch', repositoryPath: '${details.repositoryPath?.replace(/\\/g, '\\\\')}', refresh: true });
         });
          document.getElementById('repoLoadMore').addEventListener('click', () => {
           // When the button is clicked, call the extension method to perform the task
-          vscode.postMessage({ command: 'repoLoadMore', repositoryPath: '${details.repositoryPath}', refresh: true });
+          vscode.postMessage({ command: 'repoLoadMore', repositoryPath: '${details.repositoryPath?.replace(/\\/g, '\\\\')}', refresh: true });
         });
          document.getElementById('repoClearCache').addEventListener('click', () => {
           // When the button is clicked, call the extension method to perform the task
-          vscode.postMessage({ command: 'repoClearCache', repositoryPath: '${details.repositoryPath}', refresh: true });
+          vscode.postMessage({ command: 'repoClearCache', repositoryPath: '${details.repositoryPath?.replace(/\\/g, '\\\\')}', refresh: true });
         });
         ${details.commitDetails.map(commit => `
         if (document.getElementById('open-${commit.commitHash}')) {
@@ -227,17 +231,17 @@ export class GitNotesPanel {
         }
         if (document.getElementById('edit-${commit.commitHash}')) {
           document.getElementById('edit-${commit.commitHash}').addEventListener('click', () => {
-            vscode.postMessage({ command: 'commitEdit', commitHash: '${commit.commitHash}', repositoryPath: '${details.repositoryPath}', refresh: true });
+            vscode.postMessage({ command: 'commitEdit', commitHash: '${commit.commitHash}', repositoryPath: '${details.repositoryPath?.replace(/\\/g, '\\\\')}', refresh: true });
           });
         }
         if (document.getElementById('remove-${commit.commitHash}')) {
           document.getElementById('remove-${commit.commitHash}').addEventListener('click', () => {
-            vscode.postMessage({ command: 'commitRemove', commitHash: '${commit.commitHash}', repositoryPath: '${details.repositoryPath}', refresh: true });
+            vscode.postMessage({ command: 'commitRemove', commitHash: '${commit.commitHash}', repositoryPath: '${details.repositoryPath?.replace(/\\/g, '\\\\')}', refresh: true });
           });
         }
         if (document.getElementById('load-${commit.commitHash}')) {
           document.getElementById('load-${commit.commitHash}').addEventListener('click', () => {
-            vscode.postMessage({ command: 'commitLoad', commitHash: '${commit.commitHash}', repositoryPath: '${details.repositoryPath}', refresh: true });
+            vscode.postMessage({ command: 'commitLoad', commitHash: '${commit.commitHash}', repositoryPath: '${details.repositoryPath?.replace(/\\/g, '\\\\')}', refresh: true });
           });
         }
         `).join('\n')}


### PR DESCRIPTION
…emove the "//" from path

In windows the paths with "//" will remove the "'//'"

So a path like

`c:\\Users\\bob\\Documents\\GitHub\\git-notes-test`

will format as

`c:UsersbobDocumentsGitHubgit-notes-test`

I have add a replace "//" with "/" using ther replace() method on the `repositoryPath` var