### PR TITLE
🐛 Fixed issue with extension when temp edit file is opened or switched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased Changes]
 
+## [0.2.1]
+
+### Bug
+
+- 🐛 [#34](https://github.com/jrosco/vscode-git-notes/pull/34) Fixed issue with extension when temp edit file is opened or switched
+
 ## [0.2.0]
 
 ### Added
@@ -50,3 +56,4 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 [0.0.1]: https://github.com/jrosco/vscode-git-notes/compare/a9fdfb1...0.0.1
 [0.1.0]: https://github.com/jrosco/vscode-git-notes/compare/0.0.1...0.1.0
 [0.2.0]: https://github.com/jrosco/vscode-git-notes/compare/0.1.0...0.2.0
+[0.2.1]: https://github.com/jrosco/vscode-git-notes/compare/0.2.0...0.2.1-patches

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -190,14 +190,16 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.window.showTextDocument(doc, { preview: true }).then((editor) => {
             // Define bufferContent outside of the callback functions
             let bufferContent = '';
+            let document: vscode.TextDocument;
             // Listen for changes in the document to extract the commit message
             const onDidChangeDisposable = vscode.workspace.onDidChangeTextDocument((event) => {
               let activeEditor = vscode.window.activeTextEditor;
               if (!activeEditor) {
                 return;
               }
-              const document = activeEditor.document;
-              bufferContent = document.getText();
+              document = activeEditor.document;
+              // Check if the document is the temporary git edit file and get the content buffer
+              document.uri.path.match(commitHash + '.' + editorTempFileName) ? bufferContent = document.getText(): '';
               // Perform any operations you need with the buffer content here
               document.save();
             });


### PR DESCRIPTION
🐛 Fixed issue with extension when temp edit file is opened or switched the getGitRepositoryPath() and loader() code is executed