### PR TITLE
:bug: Fixed issue when opening the temp notes edit file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - 🐛 [#34](https://github.com/jrosco/vscode-git-notes/pull/34) Fixed issue with extension when temp edit file is opened or switched
 - 🐛 [#33](https://github.com/jrosco/vscode-git-notes/pull/33) There is an issue on windows with the way "//" are treated, it removes the "//" from path. This temp fix will replace the "//" with "/"
+- 🐛 [#37](https://github.com/jrosco/vscode-git-notes/pull/37) Fixed issue when opening the temp notes edit file in tab, does dispose the event correctly
 
 ## [0.2.0]
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -209,8 +209,6 @@ export function activate(context: vscode.ExtensionContext) {
               if (!editor) {
                 if (bufferContent !== '' && commitHash !== undefined) {
                   await notes.addGitNotes(bufferContent, commitHash, 'add', undefined, activeFileRepoPath, editNote);
-                  onDidChangeActiveDisposable.dispose();
-                  onDidChangeDisposable.dispose();
                 }
                 // You can perform any cleanup or handling here
                 fs.unlink(tempFilePath, (error) => {
@@ -222,6 +220,9 @@ export function activate(context: vscode.ExtensionContext) {
                   if (error) {
                     logger.debug(`Error removing the file: ${error}`);
                   }
+                  // Dispose the event listeners
+                  onDidChangeActiveDisposable.dispose();
+                  onDidChangeDisposable.dispose();
                 });
                 return;
               }


### PR DESCRIPTION
:bug: Fixed issue when opening the temp notes edit file in tab, does dispose the event correctly. #36